### PR TITLE
Fix ImportError on pygls 2.x: import LanguageServer from pygls.lsp.server

### DIFF
--- a/cst_lsp/server.py
+++ b/cst_lsp/server.py
@@ -5,7 +5,7 @@ import sys
 import libcst
 from libcst.metadata import CodePosition, CodeRange
 from lsprotocol import types as lsp
-from pygls.server import LanguageServer
+from pygls.lsp.server import LanguageServer
 
 from cst_lsp.code_actions.base import BaseCstLspCodeAction
 from cst_lsp.code_actions.extract_method import ExtractMethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "libcst>=1.4.0",
-    "pygls>=1.3.1",
+    "pygls>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #7.

pygls 2.0 moved `LanguageServer` from `pygls.server` to `pygls.lsp.server`, so
a fresh `uvx cst-lsp` install fails at import time with:

```
ImportError: cannot import name 'LanguageServer' from 'pygls.server'
```

Changes:

* `cst_lsp/server.py`: import `LanguageServer` from `pygls.lsp.server`.
* `pyproject.toml`: raise the pygls floor from `>=1.3.1` to `>=2.0.0`, since the
  new import path does not exist on pygls 1.x. Without this the declared range
  still permits a broken install.

Verified locally on Python 3.14 with pygls 2.x: `import cst_lsp.server`
succeeds and `pytest` passes (31 passed; the 4 `test_symbol_finder` failures on
my machine are due to ripgrep not being installed, not this change).
